### PR TITLE
Save cli args as string

### DIFF
--- a/rpcs3/Emu/System.cpp
+++ b/rpcs3/Emu/System.cpp
@@ -1220,8 +1220,8 @@ game_boot_result Emulator::Load(const std::string& title_id, bool add_only, bool
 				sys_log.notice("Elf path: %s", argv[0]);
 
 				// Append CLI arguments from config
-				const auto& cfg_argv = g_cfg.core.cli_args.get_vec();
-				argv.insert(argv.end(), cfg_argv.begin(), cfg_argv.end());
+				const std::string cfg_argv = g_cfg.core.cli_args.to_string();
+				// TODO: populate argv
 			}
 
 			if (!argv[0].starts_with("/dev_hdd0/game"sv) && m_cat == "HG"sv)

--- a/rpcs3/Emu/system_config.h
+++ b/rpcs3/Emu/system_config.h
@@ -59,7 +59,7 @@ struct cfg_root : cfg::node
 		cfg::_bool debug_console_mode{ this, "Debug Console Mode", false }; // Debug console emulation, not recommended
 		cfg::_bool hook_functions{ this, "Hook static functions" };
 		cfg::set_entry libraries_control{ this, "Libraries Control" }; // Override HLE/LLE behaviour of selected libs
-		cfg::vec_entry cli_args{ this, "CLI Arguments" }; // Command-Line-Interface arguments passed to the application
+		cfg::string cli_args{ this, "CLI Arguments" }; // Command-Line-Interface arguments passed to the application
 		cfg::_bool hle_lwmutex{ this, "HLE lwmutex" }; // Force alternative lwmutex/lwcond implementation
 		cfg::uint64 spu_llvm_lower_bound{ this, "SPU LLVM Lower Bound" };
 		cfg::uint64 spu_llvm_upper_bound{ this, "SPU LLVM Upper Bound", 0xffffffffffffffff };

--- a/rpcs3/rpcs3qt/emu_settings.cpp
+++ b/rpcs3/rpcs3qt/emu_settings.cpp
@@ -680,7 +680,7 @@ void emu_settings::EnhanceDoubleSpinBox(QDoubleSpinBox* spinbox, emu_settings_ty
 	});
 }
 
-void emu_settings::EnhanceLineEdit(QLineEdit* edit, emu_settings_type type, bool as_vector)
+void emu_settings::EnhanceLineEdit(QLineEdit* edit, emu_settings_type type, bool as_vector, const QRegularExpression& split_regex)
 {
 	if (!edit)
 	{
@@ -699,10 +699,10 @@ void emu_settings::EnhanceLineEdit(QLineEdit* edit, emu_settings_type type, bool
 		}
 		edit->setText(qstr(text));
 
-		connect(edit, &QLineEdit::textChanged, [type, this](const QString& text)
+		connect(edit, &QLineEdit::textChanged, [type, split_regex, this](const QString& text)
 		{
 			std::vector<std::string> vec;
-			for (const QString& elem : text.split(" "))
+			for (const QString& elem : text.split(split_regex))
 			{
 				vec.emplace_back(sstr(elem));
 			}

--- a/rpcs3/rpcs3qt/emu_settings.h
+++ b/rpcs3/rpcs3qt/emu_settings.h
@@ -54,7 +54,7 @@ public:
 	void EnhanceDoubleSpinBox(QDoubleSpinBox* spinbox, emu_settings_type type, const QString& prefix = "", const QString& suffix = "");
 
 	/** Connects a line edit with the target settings type*/
-	void EnhanceLineEdit(QLineEdit* edit, emu_settings_type type, bool as_vector = false);
+	void EnhanceLineEdit(QLineEdit* edit, emu_settings_type type, bool as_vector = false, const QRegularExpression& split_regex = QRegularExpression(""));
 
 	/** Connects a button group with the target settings type*/
 	void EnhanceRadioButton(QButtonGroup* button_group, emu_settings_type type);

--- a/rpcs3/rpcs3qt/settings_dialog.cpp
+++ b/rpcs3/rpcs3qt/settings_dialog.cpp
@@ -1057,7 +1057,7 @@ settings_dialog::settings_dialog(std::shared_ptr<gui_settings> gui_settings, std
 	}
 
 	// CLI arguments
-	m_emu_settings->EnhanceLineEdit(ui->cli_args, emu_settings_type::CommandLineArguments, true);
+	m_emu_settings->EnhanceLineEdit(ui->cli_args, emu_settings_type::CommandLineArguments);
 	SubscribeTooltip(ui->gb_cli_args, tooltips.settings.cli_args);
 
 	// HLE/LLE Libraries


### PR DESCRIPTION
- Also add support for RegExp Split in LineEdits. (unused at the moment)
- TODO: parse the cli args